### PR TITLE
Fix Call OpCode & Add 'floor', 'int' hashes.

### DIFF
--- a/src/common/hashstore.ts
+++ b/src/common/hashstore.ts
@@ -3,6 +3,8 @@ import { getHash } from './translate'
 
 const defaultHashes:{[key:number]:string} = 
 {
+  "1776456860": "floor",
+  "-1226284721": "int",
   "2612209": "DebuffNumber",
   "2621308": "Hana",
   "14492765": "MyHPRatio",

--- a/src/sources/gamecore.ts
+++ b/src/sources/gamecore.ts
@@ -209,7 +209,8 @@ export function evaluateDynamicExpression(expression?:DynamicExpression, context
           break;
         case 8: // Call
           var right = stack.pop();
-          stack.push(`Call(${bytes.charCodeAt(++i)}, ${right}`);
+          var left = stack.pop();
+          stack.push(`${left}(${right}, ${bytes.charCodeAt(++i)})`);
           break;
         case 9: // Return
           var result = stack.pop();


### PR DESCRIPTION
From what I understand for the Call opcode you need to pop the stack a 2nd time to get the hashed func name. The only func names I know are 'floor' and 'int'.